### PR TITLE
Fixed Readme Example to work with best practices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,24 @@ import SmartPicker from 'react-native-smart-picker'
 
 ...
 
+ this.state = {
+            selected: "A",
+           
+        };
+
+ handleChange(value: string) {
+        this.setState({
+            selected: value
+        });
+    }
+
 <ScrollView style={styles.container}>
   <View style={{flex: 1, marginTop: 20}}>
     <ScrollView style={styles.container}>
       <SmartPicker
-        selectedValue='CZ'
+        selectedValue={this.state.selected}
         label='Set you favorite country'
-        onValueChange={() => {this.handleChange}}
+        onValueChange={this.handleChange.bind(this)}
       >
         <Picker.Item label='Austria' value='A' />
         <Picker.Item label='Czechia' value='CZ' />

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import SmartPicker from 'react-native-smart-picker'
         });
     }
 
-<ScrollView style={styles.container}>
+<ScrollView style={"Your custom styles here"}>
   <View style={{flex: 1, marginTop: 20}}>
     <ScrollView style={styles.container}>
       <SmartPicker


### PR DESCRIPTION
The previous example had no handlechange => causing the scroll wheel to always scroll back to the "selectedValue={'value}. I added this.state to show working example along with handleChange => to manipulate the state on onValueChange =>. 

Now example will start the wheel on Austria because its Value matches "selectedValue={this.state.selected}" 